### PR TITLE
Generalized fixup parameters

### DIFF
--- a/example_config_file.yml
+++ b/example_config_file.yml
@@ -47,7 +47,7 @@ fixups:
   # by setting it to the value of the title tag found in the corresponding
   # media files.
   - name: sync_title
-    enabled: true
+    enabled: false
     kwargs:
 
       # String or list of strings that specify the library section types that

--- a/plexmediafixup/cli.py
+++ b/plexmediafixup/cli.py
@@ -243,7 +243,6 @@ def main():
     plexapi_config_path = config.data['plexapi_config_path']  # required item
     direct_connection = config.data['direct_connection']  # required item
     server_name = config.data['server_name']  # optional but defaulted item
-    path_mappings = config.data['path_mappings']  # optional but defaulted item
     fixups = config.data['fixups']  # optional but defaulted item
     fixup_mgr = FixupManager()
 
@@ -349,13 +348,13 @@ def main():
         name = fixup['name']  # required item
         enabled = fixup['enabled']  # required item
         dryrun = args.dryrun
-        kwargs = fixup.get('kwargs', dict())
+        fixup_kwargs = fixup.get('kwargs', dict())
         if enabled:
             fixup = fixup_mgr.get_fixup(name)
             print("Executing fixup: {name} (dryrun={dryrun})".
                   format(name=name, dryrun=dryrun))
             rc = fixup.run(plex=plex, dryrun=dryrun, verbose=args.verbose,
-                           path_mappings=path_mappings, **kwargs)
+                           config=config.data, fixup_kwargs=fixup_kwargs)
             if rc:
                 print("Error: Fixup {name} has encountered errors - aborting".
                       format(name=name))

--- a/plexmediafixup/fixup.py
+++ b/plexmediafixup/fixup.py
@@ -74,8 +74,20 @@ class Fixup(object):
         """
         self.name = name
 
-    def run(self, plex, dryrun, verbose, **kwargs):
+    def run(self, plex, dryrun, verbose, config, fixup_kwargs):
         """
         Funxtion to execute the fixup. Must be implemented in fixup subclass.
+
+        Parameters:
+
+          plex (plexapi.PlexServer): PMS to work against.
+
+          dryrun (bool): Dryrun flag from command line.
+
+          verbose (bool): Verbose flag from command line.
+
+          config (dict): The entire config file.
+
+          fixup_kwargs (dict): The kwargs config parameter for the fixup.
         """
         raise NotImplementedError

--- a/plexmediafixup/fixups/sync_sort_title.py
+++ b/plexmediafixup/fixups/sync_sort_title.py
@@ -53,43 +53,48 @@ class SyncSortTitle(Fixup):
     def __init__(self):
         super(SyncSortTitle, self).__init__(FIXUP_NAME)
 
-    def run(self, plex, dryrun, verbose, path_mappings,
-            section_types=None, section_pattern=None, as_ascii=False,
-            remove_specials=False):
+    def run(self, plex, dryrun, verbose, config, fixup_kwargs):
         """
-        Standard parameters:
+        Parameters:
 
           plex (plexapi.PlexServer): PMS to work against.
 
-          dryrun (bool): Dryrun flag.
+          dryrun (bool): Dryrun flag from command line.
 
-          verbose (bool): Verbose flag.
+          verbose (bool): Verbose flag from command line.
 
-          path_mappings (list(dict(server=strng, local=string))): File path
-            mappings between PMS server and local system.
+          config (dict): The entire config file.
 
-        Fixup-specific parameters (kwargs in config):
+          fixup_kwargs (dict): The kwargs config parameter for the fixup,
+            with the following items:
 
-          section_types (string or iterable(string)):
-            The library section types that should be processed. Valid values
-            are: 'movie', 'show'. For 'show', both the show item itself and its
-            episodes will be processed. A value of None (null in config file)
-            means to process all valid section types. Optional, default is None.
+            section_types (string or iterable(string)):
+              The library section types that should be processed. Valid values
+              are: 'movie', 'show'. For 'show', both the show item itself and
+              its episodes will be processed. A value of None (null in config
+              file) means to process all valid section types. Optional, default
+              is None.
 
-          section_pattern (string):
-            Regex pattern defining library section names that should be
-            processed within the configured section types. A value of None
-            (null in config file) means to process all library sections of the
-            configured types. Optional, default is None.
+            section_pattern (string):
+              Regex pattern defining library section names that should be
+              processed within the configured section types. A value of None
+              (null in config file) means to process all library sections of
+              the configured types. Optional, default is None.
 
-          as_ascii (bool):
-            Boolean that controls whether the sort title is translated to
-            7-bit ASCII characters using unidecode. Optional, default is False.
+            as_ascii (bool):
+              Boolean that controls whether the sort title is translated to
+              7-bit ASCII characters using unidecode. Optional, default is
+              False.
 
-          remove_specials (bool):
-            Boolean that controls whether special characters in the sort title
-            will be remplaced with space. Optional, default is False.
+            remove_specials (bool):
+              Boolean that controls whether special characters in the sort
+              title will be replaced with space. Optional, default is False.
         """
+
+        section_types = fixup_kwargs.get('section_types', None)
+        section_pattern = fixup_kwargs.get('section_pattern', None)
+        as_ascii = fixup_kwargs.get('as_ascii', False)
+        remove_specials = fixup_kwargs.get('remove_specials', False)
 
         if section_types is None:
            section_types = ['movie', 'show']

--- a/plexmediafixup/fixups/sync_title.py
+++ b/plexmediafixup/fixups/sync_title.py
@@ -34,35 +34,39 @@ class SyncTitle(Fixup):
     def __init__(self):
         super(SyncTitle, self).__init__(FIXUP_NAME)
 
-    def run(self, plex, dryrun, verbose, path_mappings,
-            section_types=None, section_pattern=None):
+    def run(self, plex, dryrun, verbose, config, fixup_kwargs):
         """
-        Standard parameters:
+        Parameters:
 
           plex (plexapi.PlexServer): PMS to work against.
 
-          dryrun (bool): Dryrun flag.
+          dryrun (bool): Dryrun flag from command line.
 
-          verbose (bool): Verbose flag.
+          verbose (bool): Verbose flag from command line.
 
-          path_mappings (list(dict(server=strng, local=string))): File path
-            mappings between PMS server and local system.
+          config (dict): The entire config file.
 
-        Fixup-specific parameters (kwargs in config):
+          fixup_kwargs (dict): The kwargs config parameter for the fixup,
+            with the following items:
 
-          section_types (string or iterable(string)):
-            The library section types that should be processed. Valid values
-            are: 'movie', 'show'. For 'show', only its episodes will be
-            processed (not the show item itself). A value of None (null in
-            config file) means to process all valid section types. Optional,
-            default is None.
+            section_types (string or iterable(string)):
+              The library section types that should be processed. Valid values
+              are: 'movie', 'show'. For 'show', only its episodes will be
+              processed (not the show item itself). A value of None (null in
+              config file) means to process all valid section types. Optional,
+              default is None.
 
-          section_pattern (string):
-            Regex pattern defining library section names that should be
-            processed within the configured section types. A value of None
-            (null in config file) means to process all library sections of the
-            configured types. Optional, default is None.
+            section_pattern (string):
+              Regex pattern defining library section names that should be
+              processed within the configured section types. A value of None
+              (null in config file) means to process all library sections of
+              the configured types. Optional, default is None.
         """
+
+        path_mappings = config.get('path_mappings', [])
+
+        section_types = fixup_kwargs.get('section_types', None)
+        section_pattern = fixup_kwargs.get('section_pattern', None)
 
         if section_types is None:
            section_types = ['movie', 'show']
@@ -151,9 +155,13 @@ def local_path(server_path, path_mappings):
     """
     for mapping in path_mappings:
         server_root = mapping.get('server')
+        if not server_root.endswith(os.path.sep):
+            server_root += os.path.sep
         local_root = mapping.get('local')
+        if not local_root.endswith(os.path.sep):
+            local_root += os.path.sep
         if server_path.startswith(server_root):
-            relpath = server_path[len(server_root)+1:]
+            relpath = server_path[len(server_root):]
             return os.path.join(local_root, relpath)
     return None
 


### PR DESCRIPTION
Details:

* Changed the signature of Fixup.run() as follows:

  - added a 'config' parameter that is a dict with the complete
    config file.

  - removed the path_mappings parameter. The path_mappings config parameter
    can now be obtained from the new config parameter.

  - changed the **kwargs keyword arguments to a fixup_kwargs parameter
    that is a dict with the kwargs config paranmeter of the fixup.

  Reason was to make it simpler to extend the config file, particularly
  when the new parameters are not used by all fixups. That was already
  the case for the path_mapings config parameter.

Signed-off-by: Andreas Maier <andreas.r.maier@gmx.de>